### PR TITLE
Fix circular dependency errors. Change order of bootstrap process

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
     "autoload": {
         "psr-0": {
             "Zf2for1": "src/"
-        }
+        },
+        "classmap": [
+            "src/Zf2for1/Resource"
+        ]
     }
 }

--- a/src/Zf2for1/Application/Zf2Bootstrap.php
+++ b/src/Zf2for1/Application/Zf2Bootstrap.php
@@ -80,7 +80,7 @@ class Zf2Bootstrap extends Zend_Application_Bootstrap_Bootstrap
     {
         $front = $this->getResource('frontcontroller');
         $front->setParam('bootstrap', $this);
-        $application = $this->getResource('zf2')->getApplication();
+        $application = $this->getResource('zf2');
         $config = $application->getServiceManager()->get('Config');
 
         if ($config['zf2_for_1']['silent_zf1_fallback'] === true) {


### PR DESCRIPTION
Zf2 application is initialized first and zf2 modules are loaded (service manager is configured and available to zf1 at this point), then zf1 application is bootstrapped and finally zf2 app bootstrapped